### PR TITLE
Build jar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# used to fix the language breakdown stuff (Linguist)
+
+/lib/* linguist-vendored

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     * [Rulebooks](#rulebooks)
     * [Language & Framework](#language--framework)
 - [How to Run](#how-to-run)
-    * [Jar From Command Line] (#how-to-run-.jar-from-command-line)
+    * [.jar] (#how-to-run-.jar-from-command-line)
     * [IntelliJ] (#how-to-run-intellij)
 - [Screenshots - A Glimpse of Elfenroads](#screenshots---a-glimpse-of-elfenroads)
     * [Login](#login)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Java, Swing, Minueto
 ## How to Run: .jar From Command Line
 1. Navigate to the latest release on the right side of the GitHub web UI
 2. Download play.sh and release.zip. Make sure they are in the same directory.
-3. Add run permissions to play.sh (Unix: chmod +x play.sh)
-4. Run play.sh
-NOTE: When running a second time, you can just navigate to release and run the .jar file itself (Unix: java -jar Elfenroads.jar)
+3. Add run permissions to play.sh (Unix: `chmod +x play.sh`)
+4. Run play.sh (Unix: `./play.sh`)
+NOTE: When running a second time, you can just navigate to release and run the .jar file itself (Unix: `java -jar Elfenroads.jar`)
+Requires Java 15 or later.
 
 ## How to Run: IntelliJ
 1. Clone this repository onto your local machine

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An exciting race starts among the elves to find out who will make the best use o
 ### Language & Framework
 Java, Swing, Minueto
 
-## How to Run: Jar from command line
+## How to Run: .jar From Command Line
 1. Navigate to the latest release on the right side of the GitHub web UI
 2. Download play.sh and release.zip. Make sure they are in the same directory.
 3. Add run permissions to play.sh (Unix: chmod +x play.sh)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
     * [Description](#description)
     * [Rulebooks](#rulebooks)
     * [Language & Framework](#language--framework)
-- [How to Run](#how-to-run)
+- [How to Run: Jar from command line](#how-to-run-jar-from-command-line)
+- [How to Run: IntelliJ](#how-to-run-intellij)
 - [Screenshots - A Glimpse of Elfenroads](#screenshots---a-glimpse-of-elfenroads)
     * [Login](#login)
     * [Lobby](#lobby)
@@ -40,7 +41,14 @@ An exciting race starts among the elves to find out who will make the best use o
 ### Language & Framework
 Java, Swing, Minueto
 
-## How to Run
+## How to Run: Jar from command line
+1. Navigate to the latest release on the right side of the GitHub web UI
+2. Download play.sh and release.zip. Make sure they are in the same directory.
+3. Add run permissions to play.sh (Unix: chmod +x play.sh)
+4. Run play.sh
+NOTE: When running a second time, you can just navigate to release and run the .jar file itself (Unix: java -jar Elfenroads.jar)
+
+## How to Run: IntelliJ
 1. Clone this repository onto your local machine
 2. Build the project with `Java SE 15`. In IntelliJ IDEA, go to `File` --> `Project Structure` --> `Project` --> set `SDK` and `Language Level`.
 3. Run `windows/MainFrame.java`. In IntelliJ IDEA, you can go to `MainFrame.java` and press <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd> on Windows or <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>R</kbd> on a Mac.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
     * [Description](#description)
     * [Rulebooks](#rulebooks)
     * [Language & Framework](#language--framework)
-- [How to Run: Jar from command line](#how-to-run-jar-from-command-line)
-- [How to Run: IntelliJ](#how-to-run-intellij)
+- [How to Run](#how-to-run)
+    * [Jar From Command Line] (#how-to-run-.jar-from-command-line)
+    * [IntelliJ] (#how-to-run-intellij)
 - [Screenshots - A Glimpse of Elfenroads](#screenshots---a-glimpse-of-elfenroads)
     * [Login](#login)
     * [Lobby](#lobby)
@@ -41,7 +42,9 @@ An exciting race starts among the elves to find out who will make the best use o
 ### Language & Framework
 Java, Swing, Minueto
 
-## How to Run: .jar From Command Line
+## How to Run
+
+### How to Run: .jar From Command Line
 1. Navigate to the latest release on the right side of the GitHub web UI
 2. Download play.sh and release.zip. Make sure they are in the same directory.
 3. Add run permissions to play.sh (Unix: `chmod +x play.sh`)
@@ -49,7 +52,7 @@ Java, Swing, Minueto
 NOTE: When running a second time, you can just navigate to release and run the .jar file itself (Unix: `java -jar Elfenroads.jar`)
 Requires Java 15 or later.
 
-## How to Run: IntelliJ
+### How to Run: IntelliJ
 1. Clone this repository onto your local machine
 2. Build the project with `Java SE 15`. In IntelliJ IDEA, go to `File` --> `Project Structure` --> `Project` --> set `SDK` and `Language Level`.
 3. Run `windows/MainFrame.java`. In IntelliJ IDEA, you can go to `MainFrame.java` and press <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F10</kbd> on Windows or <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>R</kbd> on a Mac.


### PR DESCRIPTION
Hi Yijia!

I built a .jar file to run the game without needing an IDE, but it's not perfect. I'm having some issues accessing stuff in the assets folder from the .jar even when they are packaged in together, so I put the assets folder in the same directory as the .jar.

The release on the sidebar is the folder release containing the .jar file and assets. The second file, play.sh, is a shell script to unzip the releases folder and automatically run (useful for first time.)

The .jar does work when run as specified in the instructions. I had to get a new credit card, so my AWS account doesn't work right now--that's why login and such won't work.

I also updated the README. The .jar works when run in the way specified in "How to run: .jar from command line."

No need to merge if you would rather not, but I thought it would be cool to have a way to run outside of an IDE.

I actually don't think this PR contains the files added to "releases," so I'll add them separately.